### PR TITLE
Fixing build issues

### DIFF
--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ pack: build_product build_test build_samples
 	ln --symbolic $(VERSION)/$(SUBDIR_INCLUDE) $(CURDIR)/$(SUBDIR_OUT)/$(PROJECT)/$(SUBDIR_INCLUDE)
 	cp -r $(CURDIR)/$(SUBDIR_BIN)/*  $(CURDIR)/$(SUBDIR_OUT)/$(PROJECT)/$(VERSION)/$(SUBDIR_BIN)
 	cp -r $(CURDIR)/$(SUBDIR_SAMPLES)/*  $(CURDIR)/$(SUBDIR_OUT)/$(PROJECT)/$(VERSION)/$(SUBDIR_SAMPLES)
-	pushd $(CURDIR)/$(SUBDIR_OUT); zip -ry9 $(PROJECT)_$(VERSION).zip $(PROJECT); popd
+	cd $(CURDIR)/$(SUBDIR_OUT); zip -ry9 $(PROJECT)_$(VERSION).zip $(PROJECT); cd $(CURDIR)
 	# ---------- Done packing ----------
 	#
 

--- a/src/json.h
+++ b/src/json.h
@@ -156,7 +156,7 @@ namespace abc {
 
 		if (size < sizeof(json::token_t)) {
 			char buffer[100];
-			std::snprintf(buffer, sizeof(buffer), "json_istream::get_token() size=%zd (< %zd) ", size, sizeof(json::token_t));
+			std::snprintf(buffer, sizeof(buffer), "json_istream::get_token() size=%zu (< %zu) ", size, sizeof(json::token_t));
 
 			throw exception<std::logic_error, Log>(buffer, 0x10100, log_local);
 		}

--- a/src/json.h
+++ b/src/json.h
@@ -156,7 +156,7 @@ namespace abc {
 
 		if (size < sizeof(json::token_t)) {
 			char buffer[100];
-			std::snprintf(buffer, sizeof(buffer), "json_istream::get_token() size=%ld (< %ld) ", (std::int32_t)size, (std::int32_t)sizeof(json::token_t));
+			std::snprintf(buffer, sizeof(buffer), "json_istream::get_token() size=%zd (< %zd) ", size, sizeof(json::token_t));
 
 			throw exception<std::logic_error, Log>(buffer, 0x10100, log_local);
 		}


### PR DESCRIPTION
- Fixing the original issue of 'popd' not being present on Ubuntu - this also shows up in WSL when the subsystem is Ubuntu 20.04

- Fixing compiler warnings on 64 bit platforms - where %ld expects a 64 bit value